### PR TITLE
Updating our snapcraft.yaml file

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -79,6 +79,7 @@ parts:
       - pulseaudio
       - shared-mime-info
       - ubuntu-settings
+      - fonts-liberation
     override-pull: |
       set -eux
       snapcraftctl pull

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -10,8 +10,6 @@ description: |
  today with our new Brave Payments system.
 confinement: strict
 base: core18
-assumes:
-  - snapd2.43
 apps:
   brave:
     command: bin/desktop-launch $SNAP/opt/brave.com/brave/brave-browser
@@ -61,9 +59,6 @@ plugs:
     interface: content
     target: $SNAP/data-dir/sounds
     default-provider: gtk-common-themes
-  brave-config:
-    interface: personal-files
-    read: [$HOME/.config/brave]
 parts:
   brave:
     plugin: dump
@@ -173,11 +168,3 @@ parts:
     prime:
       - usr/share/themes/Default/
       - usr/share/themes/Emacs/
-  xdg-email:
-    plugin: nil
-    override-pull: ""
-    override-prime: |
-      set -eu
-      mkdir -p usr/bin
-      cd usr/bin
-      ln -s /usr/bin/xdg-open xdg-email

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,79 +1,50 @@
 name: brave
 version: 1.18.70
-base: core18
+grade: stable
+architectures:
+  - build-on: amd64
 summary: Browse faster and safer with Brave.
 description: |
  The new Brave browser automatically blocks ads and trackers, making it
  faster and safer than your current browser. Start supporting publishers
  today with our new Brave Payments system.
-
-grade: stable
 confinement: strict
-
-architectures:
-  - build-on: amd64
-
-parts:
-  brave:
-    plugin: dump
-    source: https://github.com/brave/brave-browser/releases/download/v$SNAPCRAFT_PROJECT_VERSION/brave-browser_$SNAPCRAFT_PROJECT_VERSION_amd64.deb
-    source-type: deb
-    # Correct path to icon.
-    override-pull: |
-      snapcraftctl pull
-      rm -rf etc/cron.daily/
-      rm -rf usr/bin/brave-browser usr/bin/brave-browser-stable
-      chmod 0755 ./opt/brave.com/brave/chrome-sandbox
-      sed -i 's|Icon=brave-browser|Icon=/opt/brave.com/brave/product_logo_128\.png|g' usr/share/applications/brave-browser.desktop
-      sed -i -e '/^Actions=/d' usr/share/applications/brave-browser.desktop
-    after:
-      - desktop-gtk3
-    stage-packages:
-      - gir1.2-gnomekeyring-1.0
-      - libasound2
-      - libgconf-2-4
-      - libgl1-mesa-glx
-      - libglu1-mesa
-      - libgnome-keyring0
-      - libcap2
-      - libgcrypt20
-      - libnotify4
-      - libnspr4
-      - libnss3
-      - libpulse0
-      - libxtst6
-      - libxss1
-
+base: core18
+assumes:
+  - snapd2.43
 apps:
   brave:
     command: bin/desktop-launch $SNAP/opt/brave.com/brave/brave-browser
     desktop: usr/share/applications/brave-browser.desktop
-    # Correct the TMPDIR path for Chromium Framework/Electron to
-    # ensure libappindicator has readable resources.
     environment:
-      # Correct the TMPDIR path for Chromium Framework/Electron to
-      # ensure libappindicator has readable resources
-      TMPDIR: $XDG_RUNTIME_DIR
-      # Fallback to XWayland if running in a Wayland session.
       DISABLE_WAYLAND: 1
+      BRAVE_DESKTOP: brave-browser.desktop
+      BRAVE_CONFIG_HOME: $SNAP_USER_COMMON
     plugs:
-      - avahi-observe
-      - browser-sandbox
+      - audio-playback
+      - audio-record
+      - bluez
       - camera
       - cups-control
       - desktop
       - gsettings
       - home
+      - joystick
       - mount-observe
       - network
+      - network-manager
       - opengl
       - password-manager-service
       - pulseaudio
+      - raw-usb
+      - removable-media
       - screen-inhibit-control
+      - u2f-devices
       - unity7
       - upower-observe
       - x11
-
+    slots:
+      - mpris
 plugs:
   browser-sandbox:
     interface: browser-support
@@ -90,3 +61,121 @@ plugs:
     interface: content
     target: $SNAP/data-dir/sounds
     default-provider: gtk-common-themes
+  brave-config:
+    interface: personal-files
+    read: [$HOME/.config/brave]
+parts:
+  brave:
+    plugin: dump
+    source: https://github.com/brave/brave-browser/releases/download/v$SNAPCRAFT_PROJECT_VERSION/brave-browser_$SNAPCRAFT_PROJECT_VERSION_amd64.deb
+    after: [desktop-gtk3, gtk-key-themes]
+    stage-packages:
+      - libgbm1
+      - libgl1-mesa-glx
+      - libgtk-3-0
+      - libnss3
+      - libsecret-1-0
+      - libxss1
+      - pulseaudio
+      - shared-mime-info
+      - ubuntu-settings
+    override-pull: |
+      set -eux
+      snapcraftctl pull
+      rm -rf etc/cron.daily/ usr/bin/brave-browser usr/bin/brave-browser-stable
+      sed -i 's|Icon=brave-browser|Icon=/opt/brave.com/brave/product_logo_128\.png|g' usr/share/applications/brave-browser.desktop
+    prime:
+      - -etc/gss
+      - -etc/init.d
+      - -etc/sensors.d
+      - -etc/ucf.conf
+      - -etc/xdg
+      - -usr/include
+      - -usr/lib/tmpfiles.d
+      - -usr/share/apport
+      - -usr/share/bash-completion
+      - -usr/share/bug
+      - -usr/share/doc
+      - -usr/share/doc-base
+      - -usr/share/gettext
+      - -usr/share/gnome-control-center
+      - -usr/share/GConf
+      - -usr/share/icons
+      - -usr/share/lintian
+      - -usr/share/man
+      - -usr/share/pam-configs
+      - -usr/share/pkgconfig
+      - -usr/share/polkit-1
+      - -usr/share/session-migration
+      - -usr/share/sounds
+      - -usr/share/ubuntu
+      - -usr/share/ubuntu-wayland
+      - -usr/share/upstart
+      - -usr/share/zsh
+      - -var
+      - -opt/brave.com/brave/chrome-sandbox
+  desktop-gtk3:
+    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
+    source-subdir: gtk
+    plugin: make
+    make-parameters: ["FLAVOR=gtk3"]
+    build-packages:
+      - build-essential
+      - libgtk-3-dev
+    stage-packages:
+      - libxkbcommon0
+      - ttf-ubuntu-font-family
+      - shared-mime-info
+      - libgtk-3-0
+      - libgdk-pixbuf2.0-0
+      - libglib2.0-bin
+      - libgtk-3-bin
+      - unity-gtk3-module
+      - locales-all
+      - xdg-user-dirs
+      - ibus-gtk3
+      - libibus-1.0-5
+      - fcitx-frontend-gtk3
+    prime:
+      - -etc/gss
+      - -etc/presage.xml
+      - -etc/ucf.conf
+      - -etc/X11
+      - -usr/lib/glib-networking
+      - -usr/lib/systemd
+      - -usr/share/apport
+      - -usr/share/bash-completion
+      - -usr/share/doc
+      - -usr/share/doc-base
+      - -usr/share/gettext
+      - -usr/share/GConf
+      - -usr/share/icons
+      - -usr/share/lintian
+      - -usr/share/man
+      - -usr/share/pkgconfig
+      - -usr/share/presage
+      - -usr/share/upstart
+      - -var
+  shared-mime-info:
+    after: [brave]
+    plugin: nil
+    override-pull: ""
+    override-prime: |
+      set -eux
+      glib-compile-schemas usr/share/glib-2.0/schemas
+      update-mime-database usr/share/mime
+  gtk-key-themes:
+    plugin: nil
+    stage-packages:
+      - libgtk-3-common
+    prime:
+      - usr/share/themes/Default/
+      - usr/share/themes/Emacs/
+  xdg-email:
+    plugin: nil
+    override-pull: ""
+    override-prime: |
+      set -eux
+      mkdir -p usr/bin
+      cd usr/bin
+      ln -s /usr/bin/xdg-open xdg-email

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -81,8 +81,9 @@ parts:
       - ubuntu-settings
       - fonts-liberation
     override-pull: |
-      set -eux
+      set -eu
       snapcraftctl pull
+      chmod 0755 ./opt/brave.com/brave/chrome-sandbox
       rm -rf etc/cron.daily/ usr/bin/brave-browser usr/bin/brave-browser-stable
       sed -i 's|Icon=brave-browser|Icon=/opt/brave.com/brave/product_logo_128\.png|g' usr/share/applications/brave-browser.desktop
     prime:
@@ -162,7 +163,7 @@ parts:
     plugin: nil
     override-pull: ""
     override-prime: |
-      set -eux
+      set -eu
       glib-compile-schemas usr/share/glib-2.0/schemas
       update-mime-database usr/share/mime
   gtk-key-themes:
@@ -176,7 +177,7 @@ parts:
     plugin: nil
     override-pull: ""
     override-prime: |
-      set -eux
+      set -eu
       mkdir -p usr/bin
       cd usr/bin
       ln -s /usr/bin/xdg-open xdg-email


### PR DESCRIPTION
I updated out snapcraft.yaml file based on the [Chromium snapcraft file](https://chromium.googlesource.com/chromium/src/+/master/chrome/installer/linux/snap/snapcraft.yaml.in) that had support for Web Bluetooth and WebUSB.

I also explicitly added `fonts-liberations` into the snap in an attempt to fix: https://github.com/brave/brave-browser/issues/13064