### PR TITLE
Add desktop-legacy interface for CJKV users

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -25,6 +25,7 @@ apps:
       - camera
       - cups-control
       - desktop
+      - desktop-legacy
       - gsettings
       - home
       - joystick


### PR DESCRIPTION
Add [desktop-legacy interface](https://snapcraft.io/docs/desktop-legacy-interface) in order to support Linux IME users.
Without this, CJKV users can only type English characters.

Result:

![](https://i.imgur.com/s7jIy9t.png)