### PR TITLE
Fix mpris slot name

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -46,6 +46,10 @@ plugs:
   browser-sandbox:
     interface: browser-support
     allow-sandbox: true
+slots:
+  mpris:
+    interface: mpris
+    name: chromium
 parts:
   brave:
     plugin: dump


### PR DESCRIPTION
Resolves brave/brave-browser#16187

MPRIS enables desktop environments (e.g. GNOME) to provide media player
controls for media playing in the browser.

Brave uses DBus name `org.mpris.MediaPlayer2.chromium` whereas Snap sets
an AppArmor rule for `org.mpris.MediaPlayer2.brave` by default. Setting
the name parameter explicitly for the slot makes Snap generate a
compatible AppArmor rule.