### PR TITLE
Changed the mpris slot name to "brave"

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -49,7 +49,7 @@ plugs:
 slots:
   mpris:
     interface: mpris
-    name: chromium
+    name: brave
 parts:
   brave:
     plugin: dump


### PR DESCRIPTION
This is a follow-up to https://github.com/brave/brave-browser-snap/pull/19, prompted by a request from the Snap store folks