### PR TITLE
Revert "Fix mpris slot name"

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -46,10 +46,6 @@ plugs:
   browser-sandbox:
     interface: browser-support
     allow-sandbox: true
-slots:
-  mpris:
-    interface: mpris
-    name: chromium
 parts:
   brave:
     plugin: dump


### PR DESCRIPTION
Reverts brave/brave-browser-snap#19

mpris slot name should now use the default of "brave" now that https://github.com/brave/brave-core/pull/17440 has been merged.